### PR TITLE
fix: debounce cacheSectionOffsets on resize

### DIFF
--- a/app.js
+++ b/app.js
@@ -1231,9 +1231,13 @@ var SiteNav = (function () {
       }
     }
 
-    // Cache section positions (recompute on resize)
+    // Cache section positions (recompute on resize, debounced)
     cacheSectionOffsets();
-    window.addEventListener('resize', cacheSectionOffsets, { passive: true });
+    var resizeTimer = null;
+    window.addEventListener('resize', function () {
+      if (resizeTimer) clearTimeout(resizeTimer);
+      resizeTimer = setTimeout(cacheSectionOffsets, 200);
+    }, { passive: true });
 
     // Smooth scroll + close mobile menu on click
     linksContainer.addEventListener('click', function (e) {


### PR DESCRIPTION
Fixes #21

Wraps resize handler in 200ms debounce. Prevents 16 forced layout recalculations per frame during window resize drag.