### PR TITLE
fix: cap ActivityFeed today counter to prevent unbounded growth

### DIFF
--- a/__tests__/activity.test.js
+++ b/__tests__/activity.test.js
@@ -250,6 +250,18 @@ describe('ActivityFeed', () => {
       const updated = parseInt(el.textContent.replace(/,/g, ''), 10);
       expect(updated).toBeGreaterThanOrEqual(initial);
     });
+
+    test('today count stays bounded below 25001', () => {
+      const el = document.getElementById('activityTodayCount');
+      // Set to a high value close to the cap
+      el.textContent = '24,999';
+
+      // Run many cycles to push past the cap
+      jest.advanceTimersByTime(60000);
+
+      const val = parseInt(el.textContent.replace(/,/g, ''), 10);
+      expect(val).toBeLessThanOrEqual(25000);
+    });
   });
 
   describe('CSS', () => {

--- a/app.js
+++ b/app.js
@@ -3116,6 +3116,7 @@ var ActivityFeed = (function () {
     active += Math.floor(Math.random() * 5) - 2;
     if (active < 1000) active = 1000;
     today += Math.floor(Math.random() * 3) + 1;
+    if (today > 25000) today = 18000 + Math.floor(Math.random() * 2000);
 
     activeCountEl.textContent = active.toLocaleString();
     todayCountEl.textContent = today.toLocaleString();


### PR DESCRIPTION
Fixes #36

The \	ickCounters()\ function incremented the \	oday\ counter by 1-3 every cycle but never capped it, causing unrealistic numbers (50,000+) if a user leaves the page open for hours.

**Fix:** When \	oday > 25000\, reset to a random value in 18,000-20,000 (matching the initial seed range). Mirrors the existing lower-bound pattern on \ctive\.

**Test added:** Verifies the counter stays bounded below 25,001 after many cycles.