### PR TITLE
fix: FeatureBoard popular filter ignores user votes in ranking

### DIFF
--- a/app.js
+++ b/app.js
@@ -7051,7 +7051,11 @@ var FeatureBoard = (function () {
   function getFiltered() {
     if (activeFilter === "all") return allFeatures.slice();
     if (activeFilter === "popular") {
-      return allFeatures.slice().sort(function (a, b) { return b.votes - a.votes; }).slice(0, 6);
+      return allFeatures.slice().sort(function (a, b) {
+        var va = a.votes + (userVotes[a.id] ? 1 : 0);
+        var vb = b.votes + (userVotes[b.id] ? 1 : 0);
+        return vb - va;
+      }).slice(0, 6);
     }
     if (activeFilter === "new") {
       return allFeatures.filter(function (f) { return f.status === "new"; });


### PR DESCRIPTION
## Bug

`getFiltered('popular')` sorts features by raw seed votes (`b.votes - a.votes`) to select the top 6, ignoring user votes stored in `userVotes`. This means:

1. A user votes on feature X (seed votes: 50)
2. Feature X should now rank as 51, potentially entering the top 6
3. But `getFiltered` still sees it as 50 and excludes it
4. `render()` correctly includes user votes in its sort, but only reorders the already-filtered set -- it can't add back excluded features

## Fix

Include `userVotes` in the popular filter sort, matching the sort logic in `render()`:

`js
// Before (bug)
return allFeatures.slice().sort(function (a, b) { return b.votes - a.votes; }).slice(0, 6);

// After (fix)
return allFeatures.slice().sort(function (a, b) {
    var va = a.votes + (userVotes[a.id] ? 1 : 0);
    var vb = b.votes + (userVotes[b.id] ? 1 : 0);
    return vb - va;
}).slice(0, 6);
`

+5 lines, -1 line. No new dependencies.
