### PR TITLE
fix: respect OS color scheme preference when no saved theme

### DIFF
--- a/__tests__/bugfix-theme-autoplay.test.js
+++ b/__tests__/bugfix-theme-autoplay.test.js
@@ -120,6 +120,44 @@ describe('ThemeToggle null-safety', () => {
       expect(icon.textContent).toBe('🌙');
     }
   });
+
+  test('init respects prefers-color-scheme: light when no saved theme', () => {
+    // No saved theme
+    localStorage.removeItem('agentbox-theme');
+
+    // Mock matchMedia to report light preference
+    const original = window.matchMedia;
+    window.matchMedia = jest.fn((query) => {
+      if (query === '(prefers-color-scheme: light)') {
+        return { matches: true, addEventListener: jest.fn() };
+      }
+      return original ? original(query) : { matches: false, addEventListener: jest.fn() };
+    });
+
+    loadPage();
+
+    expect(document.body.classList.contains('light-mode')).toBe(true);
+
+    window.matchMedia = original;
+  });
+
+  test('init stays dark when system prefers dark and no saved theme', () => {
+    localStorage.removeItem('agentbox-theme');
+
+    const original = window.matchMedia;
+    window.matchMedia = jest.fn((query) => {
+      if (query === '(prefers-color-scheme: light)') {
+        return { matches: false, addEventListener: jest.fn() };
+      }
+      return original ? original(query) : { matches: false, addEventListener: jest.fn() };
+    });
+
+    loadPage();
+
+    expect(document.body.classList.contains('light-mode')).toBe(false);
+
+    window.matchMedia = original;
+  });
 });
 
 // ── Testimonials autoplay reset ─────────────────────────────────────────

--- a/app.js
+++ b/app.js
@@ -2669,6 +2669,15 @@ var ThemeToggle = (function () {
     if (saved === 'light') {
       document.body.classList.add('light-mode');
       if (icon) icon.textContent = '🌙';
+    } else if (saved === null) {
+      // No saved preference — respect OS-level prefers-color-scheme.
+      // Without this, users with system light-mode see the dark theme
+      // until they manually toggle, which is jarring.
+      var preferLight = window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches;
+      if (preferLight) {
+        document.body.classList.add('light-mode');
+        if (icon) icon.textContent = '🌙';
+      }
     }
 
     btn.addEventListener('click', toggle);


### PR DESCRIPTION
## Problem

ThemeToggle.init() only checked for a saved 'light' theme in localStorage. First-time visitors with OS-level light mode preference still saw the dark theme until they manually toggled — a jarring UX mismatch.

## Fix

When no saved theme exists in localStorage, check \window.matchMedia('(prefers-color-scheme: light)')\ and apply light mode automatically. This respects the user's system preference as a sensible default.

## Changes
- \pp.js\: Added \prefers-color-scheme\ fallback in \ThemeToggle.init()\
- \__tests__/bugfix-theme-autoplay.test.js\: Added 2 tests for system preference detection (light and dark)