### PR TITLE
fix: remove orphaned typing indicators on scenario switch

### DIFF
--- a/app.js
+++ b/app.js
@@ -209,6 +209,17 @@ var ChatDemo = (function () {
       cancelAnimationFrame(scrollRafId);
       scrollRafId = 0;
     }
+    // Remove any orphaned typing indicators left from the previous scenario.
+    // When switchTo() fires mid-animation, a typing indicator may already be
+    // in the DOM waiting for its setTimeout callback — which will now bail
+    // via isStale(), leaving the indicator visible.  Clean them up here.
+    var chatWindow = document.getElementById('chatWindow');
+    if (chatWindow) {
+      var orphans = chatWindow.querySelectorAll('.typing-indicator');
+      for (var oi = 0; oi < orphans.length; oi++) {
+        orphans[oi].parentNode.removeChild(orphans[oi]);
+      }
+    }
     if (!_scenarioBtns) {
       _scenarioBtns = document.querySelectorAll('.scenario-btn');
     }


### PR DESCRIPTION
When switchTo() fires while a bot message animation is mid-flight, the typing indicator is already in the DOM. The stale generation check prevents the callback from replacing it with the actual bubble, leaving a phantom typing indicator visible indefinitely.

This PR cleans up any .typing-indicator elements in chatWindow at the start of switchTo() to prevent this visual artifact.

**Steps to reproduce:**
1. Rapidly click between different scenario buttons
2. Sometimes a typing indicator remains visible after the new scenario starts

**Fix:** Added cleanup of orphaned typing indicators in switchTo().