### PR TITLE
fix(#40): prevent visible counter drops in ActivityFeed

### DIFF
--- a/__tests__/activity.test.js
+++ b/__tests__/activity.test.js
@@ -262,6 +262,36 @@ describe('ActivityFeed', () => {
       const val = parseInt(el.textContent.replace(/,/g, ''), 10);
       expect(val).toBeLessThanOrEqual(25000);
     });
+
+    test('today count never drops (issue #40)', () => {
+      const el = document.getElementById('activityTodayCount');
+      let prev = parseInt(el.textContent.replace(/,/g, ''), 10);
+
+      // Run 50 cycles and verify counter never decreases
+      for (let i = 0; i < 50; i++) {
+        jest.advanceTimersByTime(4000);
+        const current = parseInt(el.textContent.replace(/,/g, ''), 10);
+        expect(current).toBeGreaterThanOrEqual(prev);
+        prev = current;
+      }
+    });
+
+    test('active count does not frequently drop (biased upward)', () => {
+      const el = document.getElementById('activityActiveCount');
+      let prev = parseInt(el.textContent.replace(/,/g, ''), 10);
+      let drops = 0;
+
+      // Run 100 cycles and count how many times active drops
+      for (let i = 0; i < 100; i++) {
+        jest.advanceTimersByTime(4000);
+        const current = parseInt(el.textContent.replace(/,/g, ''), 10);
+        if (current < prev) drops++;
+        prev = current;
+      }
+      // With biased-upward (-1 to +2), drops should be ~25% of ticks
+      // Previously (-2 to +2), drops were ~40%. Allow up to 35%.
+      expect(drops).toBeLessThan(35);
+    });
   });
 
   describe('CSS', () => {

--- a/app.js
+++ b/app.js
@@ -3114,11 +3114,22 @@ var ActivityFeed = (function () {
     let active = parseInt(activeCountEl.textContent.replace(/,/g, ''), 10) || 1247;
     let today = parseInt(todayCountEl.textContent.replace(/,/g, ''), 10) || 18392;
 
-    // Random small fluctuation
-    active += Math.floor(Math.random() * 5) - 2;
+    // Active counter: biased-upward fluctuation (-1 to +2) so it
+    // doesn't visibly drop frequently.  Floor at 1000.
+    active += Math.floor(Math.random() * 4) - 1;
     if (active < 1000) active = 1000;
-    today += Math.floor(Math.random() * 3) + 1;
-    if (today > 25000) today = 18000 + Math.floor(Math.random() * 2000);
+
+    // Today counter: diminishing increments near the cap so it never
+    // visibly jumps backwards.  Slows to +0/+1 above 24,000 and
+    // stalls at 25,000 until the next page load resets it.
+    if (today < 22000) {
+      today += Math.floor(Math.random() * 3) + 1;          // +1..+3
+    } else if (today < 24000) {
+      today += Math.floor(Math.random() * 2) + 1;          // +1..+2
+    } else if (today < 25000) {
+      today += Math.random() < 0.5 ? 1 : 0;                // +0..+1
+    }
+    // At or above 25,000: no further increment (stalls gracefully)
 
     activeCountEl.textContent = active.toLocaleString();
     todayCountEl.textContent = today.toLocaleString();


### PR DESCRIPTION
## Fix: ActivityFeed counter jumps

**Issue:** #40

Today counter had a hard reset from 25,000 → ~18,000-20,000, causing a visible ~7,000 drop. Active counter fluctuated -2 to +2, causing frequent visible decreases.

### Changes
- **Today counter**: Diminishing increments near cap (+3→+2→+1→stall). Never drops.
- **Active counter**: Biased upward (-1 to +2 instead of -2 to +2). Drops ~25% vs ~40%.
- 2 new tests verifying monotonic today counter and bounded active drops.

All 34 activity tests passing.

Closes #40